### PR TITLE
Adding Scryfall Required Headers.

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -19,7 +19,12 @@ module.exports = NodeHelper.create({
 
 async function GetCard(uri, sender){
   var imgUrl;
-  await fetch(uri).then((response) => response.json())
+  await fetch(uri, {
+              headers: {
+                  "User-Agent": "MMM-MTG",
+                  "Accept": "*/*"
+              }
+  }).then((response) => response.json())
   .then(data => {
       imgUrl = data;
   })


### PR DESCRIPTION
Scryfall changed their API to disallow default library User-Agent headers. Creating a unique header for the magic mirror module. See https://scryfall.com/docs/api